### PR TITLE
Supertreebase validation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+aclocal.m4
+autom4te.cache
+config.h.in

--- a/xsd/characters/abstractcharacters.xsd
+++ b/xsd/characters/abstractcharacters.xsd
@@ -237,7 +237,7 @@
                 &gt; 9, and hence need to be space-separated).
             </xs:documentation>
         </xs:annotation>
-        <xs:list itemType="xs:double"/>
+        <xs:list itemType="xs:string"/>
     </xs:simpleType>
 
     <xs:complexType name="AbstractSeqRow" abstract="true">

--- a/xsd/meta/annotations.xsd
+++ b/xsd/meta/annotations.xsd
@@ -47,7 +47,17 @@
 			</xs:documentation>
 		</xs:annotation>
 		<xs:sequence/>
-		<xs:attribute ref="xml:base" />
+		<!-- It is probable that we want to allow every
+             attribute that is in xs:attributeGroup ref="xml:specialAttrs"
+             However, doing this causes clashes between xml:id
+             and the id attribute in IDTagged (which is 
+             an extension of Base).  Thus, we are 
+             just allowing xml:base here from the xml:specialAttrs
+             group. xml:base is included in several elements by 
+             treebase in NeXML exports, so it would be nice to allow
+             it.
+             -->
+        <xs:attribute ref="xml:base" />
 		<!--xs:attribute name="id" type="xs:ID" use="optional"/-->
 		<xs:anyAttribute namespace="##any" processContents="skip"/>
 	</xs:complexType>

--- a/xsd/meta/annotations.xsd
+++ b/xsd/meta/annotations.xsd
@@ -47,7 +47,7 @@
 			</xs:documentation>
 		</xs:annotation>
 		<xs:sequence/>
-		<!-- <xs:attributeGroup ref="xml:specialAttrs" /> -->		
+		<xs:attribute ref="xml:base" />
 		<!--xs:attribute name="id" type="xs:ID" use="optional"/-->
 		<xs:anyAttribute namespace="##any" processContents="skip"/>
 	</xs:complexType>


### PR DESCRIPTION
This series of commits allowed several of the TreeBase produced nexml files to validate (using xmllint and the validator available from http://code.google.com/p/xml-validator/ ). xml:base attribute is explicitly allowed in the Base object and the AbstractTokenList that underlies "seq" elements in character matrices was redefined to be base on a string (rather than a double).
